### PR TITLE
Use straight cosmo theme, no dark/light

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -46,9 +46,7 @@ website:
 
 format:
   html:
-    theme:
-      light: [cosmo, theme.scss] # from https://github.com/sta210-s22/website/blob/main/_quarto.yml
-      dark: [cosmo, theme-dark.scss]
+    theme: cosmo
     code-copy: true
     code-overflow: wrap
     toc: true


### PR DESCRIPTION
A tiny change here @stefaniebutland - nothing to test really, it sets only one theme rather than a dark and a light, and this has the effect of removing the toggle in the side bar

Closes #37 